### PR TITLE
Impl [Modal] add sub title prop in the header 

### DIFF
--- a/src/lib/components/FormChipCell/FormChipCell.js
+++ b/src/lib/components/FormChipCell/FormChipCell.js
@@ -74,10 +74,9 @@ const FormChipCell = ({
         }
       : generateChipsList(
           get(formState.values, name),
-          visibleChipsMaxLength ? visibleChipsMaxLength : visibleChipsCount,
-          delimiter
+          visibleChipsMaxLength ? visibleChipsMaxLength : visibleChipsCount
         )
-  }, [visibleChipsMaxLength, isEditMode, visibleChipsCount, delimiter, formState.values, name])
+  }, [visibleChipsMaxLength, isEditMode, visibleChipsCount, formState.values, name])
 
   const handleResize = useCallback(() => {
     if (!isEditMode && !isEveryObjectValueEmpty(chipsSizes)) {

--- a/src/lib/components/FormChipCell/FormChipCellView.js
+++ b/src/lib/components/FormChipCell/FormChipCellView.js
@@ -91,7 +91,7 @@ const FormChipCellView = React.forwardRef(
                     const chipData = fields.value[index]
                     return (
                       index < chips.visibleChips.length && (
-                        <div className="chip-block" key={chipData.id}>
+                        <div className="chip-block" key={chipData.id || chipData.key}>
                           <Tooltip
                             hidden={editConfig.isEdit}
                             key={chipData.id}

--- a/src/lib/components/FormChipCell/FormChipCellView.js
+++ b/src/lib/components/FormChipCell/FormChipCellView.js
@@ -91,7 +91,7 @@ const FormChipCellView = React.forwardRef(
                     const chipData = fields.value[index]
                     return (
                       index < chips.visibleChips.length && (
-                        <div className="chip-block" key={chipData.id || chipData.key}>
+                        <div className="chip-block" key={chipData.id}>
                           <Tooltip
                             hidden={editConfig.isEdit}
                             key={chipData.id}

--- a/src/lib/components/FormCombobox/FormCombobox.js
+++ b/src/lib/components/FormCombobox/FormCombobox.js
@@ -346,8 +346,9 @@ const FormCombobox = ({
               )}
             </div>
             <input
-              className="form-field-combobox__input form-field__control"
-              disabled={selectValue.id.length === 0}
+              className={`form-field-combobox__input ${
+                selectValue.id.length === 0 ? 'form-field-combobox__input_hidden' : ''
+              }`}
               onChange={handleInputChange}
               onFocus={inputOnFocus}
               placeholder={inputPlaceholder}

--- a/src/lib/components/FormCombobox/FormCombobox.js
+++ b/src/lib/components/FormCombobox/FormCombobox.js
@@ -79,6 +79,10 @@ const FormCombobox = ({
   useDetectOutsideClick(comboboxRef, () => setShowValidationRules(false))
 
   const labelClassNames = classnames('form-field__label', disabled && 'form-field__label-disabled')
+  const inputClassNames = classnames(
+    'form-field-combobox__input',
+    selectValue.id.length === 0 && 'form-field-combobox__input_hidden'
+  )
 
   useEffect(() => {
     setValidationRules((prevState) =>
@@ -346,9 +350,7 @@ const FormCombobox = ({
               )}
             </div>
             <input
-              className={`form-field-combobox__input ${
-                selectValue.id.length === 0 ? 'form-field-combobox__input_hidden' : ''
-              }`}
+              className={inputClassNames}
               onChange={handleInputChange}
               onFocus={inputOnFocus}
               placeholder={inputPlaceholder}

--- a/src/lib/components/FormCombobox/formCombobox.scss
+++ b/src/lib/components/FormCombobox/formCombobox.scss
@@ -13,11 +13,11 @@
       .form-field-combobox__icon {
         cursor: pointer;
         padding: 0;
+        transition: transform 200ms linear;
 
         &_open {
           transform: rotate(90deg);
           transform-origin: center center;
-          transition: transform 200ms linear;
         }
       }
     }
@@ -29,21 +29,31 @@
         text-align: left;
         text-transform: capitalize;
         background-color: transparent;
+
+        label {
+          cursor: inherit;
+        }
       }
+
       &__select {
-        flex: unset;
         padding: 0;
-        max-width: 110px;
         overflow: visible;
 
         &-header {
           display: flex;
+          flex: 1;
           align-items: center;
+          cursor: pointer;
         }
       }
 
       &__input {
+        width: 100%;
         padding: 0;
+
+        &_hidden {
+          flex: 0;
+        }
       }
     }
   }
@@ -59,7 +69,6 @@
       align-items: center;
       margin: 0 9px;
       border-bottom: $dividerBorder;
-
     }
   }
 
@@ -101,7 +110,7 @@
     }
   }
 
-  & .path-type,
+  .path-type,
   &__dropdown .path-type {
     &-store {
       color: $amethyst;

--- a/src/lib/components/FormTextarea/formTextarea.scss
+++ b/src/lib/components/FormTextarea/formTextarea.scss
@@ -7,7 +7,9 @@
   width: 100%;
 
   textarea {
+    height: inherit;
     width: 100%;
+    padding: 12px 16px;
     white-space: normal;
   }
 
@@ -17,11 +19,6 @@
     &__wrapper {
       .form-field__control {
         padding: 0;
-
-        & > *:first-child {
-          height: inherit;
-          padding: 12px 0 12px 16px;
-        }
       }
     }
 

--- a/src/lib/components/Modal/Modal.js
+++ b/src/lib/components/Modal/Modal.js
@@ -29,7 +29,7 @@ import { ReactComponent as CloseIcon } from '../../images/close.svg'
 
 import './Modal.scss'
 
-const Modal = ({ actions, children, className, location, onClose, size, show, title }) => {
+const Modal = ({ actions, children, className, onClose, size, show, subTitle, title }) => {
   const modalClassNames = classNames('modal', className, size && `modal-${size}`)
 
   return (
@@ -45,6 +45,7 @@ const Modal = ({ actions, children, className, location, onClose, size, show, ti
           <div className="modal__content">
             <div className="modal__header">
               <h5 className="modal__header-title">{title}</h5>
+              {subTitle && <h6 className="modal__header-subTitle">{subTitle}</h6>}
             </div>
             <div className="modal__body">{children}</div>
             {actions && actions.length > 0 && (
@@ -67,6 +68,7 @@ Modal.defaultProps = {
   actions: [],
   show: false,
   size: MODAL_MD,
+  subTitle: null,
   title: ''
 }
 
@@ -78,10 +80,10 @@ Modal.propTypes = {
     PropTypes.node,
     PropTypes.string
   ]).isRequired,
-  location: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
   size: MODAL_SIZES,
+  subTitle: PropTypes.string,
   title: PropTypes.string
 }
 

--- a/src/lib/components/Modal/Modal.js
+++ b/src/lib/components/Modal/Modal.js
@@ -45,7 +45,7 @@ const Modal = ({ actions, children, className, onClose, size, show, subTitle, ti
           <div className="modal__content">
             <div className="modal__header">
               <h5 className="modal__header-title">{title}</h5>
-              {subTitle && <h6 className="modal__header-subTitle">{subTitle}</h6>}
+              {subTitle && <h6 className="modal__header-sub-title">{subTitle}</h6>}
             </div>
             <div className="modal__body">{children}</div>
             {actions && actions.length > 0 && (

--- a/src/lib/components/Modal/Modal.scss
+++ b/src/lib/components/Modal/Modal.scss
@@ -55,7 +55,7 @@
       margin: 0;
     }
 
-    &-subTitle {
+    &-sub-title {
       color: $primary;
       font-size: 1.5em;
       font-weight: 400;

--- a/src/lib/components/Modal/Modal.scss
+++ b/src/lib/components/Modal/Modal.scss
@@ -58,6 +58,13 @@
       margin: 0;
     }
 
+    &-subTitle {
+      color: $primary;
+      font-size: 1em;
+      font-weight: 400;
+      line-height: 2em;
+    }
+
     &-button {
       position: absolute;
       top: 10px;

--- a/src/lib/components/Modal/Modal.scss
+++ b/src/lib/components/Modal/Modal.scss
@@ -43,26 +43,24 @@
 
   &__header {
     position: relative;
-    padding: 1.5rem 2rem;
-    display: flex;
-    flex-shrink: 0;
-    justify-content: center;
-    align-items: center;
     border-bottom: $primaryBorder;
+    text-align: center;
+    vertical-align: middle;
+    padding: 1.5rem 2rem;
 
     &-title {
       color: $primary;
       font-size: 2em;
-      font-weight: 400;
       text-transform: capitalize;
       margin: 0;
     }
 
     &-subTitle {
       color: $primary;
-      font-size: 1em;
+      font-size: 1.5em;
       font-weight: 400;
       line-height: 2em;
+      margin: 0;
     }
 
     &-button {

--- a/src/lib/components/Wizard/Wizard.js
+++ b/src/lib/components/Wizard/Wizard.js
@@ -36,6 +36,7 @@ const Wizard = ({
   onWizardSubmit,
   location,
   size,
+  subTitle,
   title,
   stepsConfig,
   submitButtonLabel
@@ -125,6 +126,7 @@ const Wizard = ({
       location={location}
       show={isWizardOpen}
       size={size}
+      subTitle={subTitle}
       title={title}
     >
       <WizardSteps activeStepNumber={activeStepNumber} jumpToStep={jumpToStep} steps={stepsMenu} />
@@ -138,7 +140,8 @@ Wizard.defaultProps = {
   confirmClose: false,
   size: MODAL_MD,
   stepsConfig: [],
-  submitButtonLabel: 'Submit'
+  submitButtonLabel: 'Submit',
+  subTitle: null
 }
 
 Wizard.propsTypes = {
@@ -150,6 +153,7 @@ Wizard.propsTypes = {
   onWizardSubmit: PropTypes.func.isRequired,
   location: PropTypes.string.isRequired,
   size: MODAL_SIZES,
+  subTitle: PropTypes.string,
   title: PropTypes.string.isRequired,
   stepsConfig: WIZARD_STEPS_CONFIG,
   submitButtonLabel: PropTypes.string


### PR DESCRIPTION
- **Modal**: add sub title prop in the header
   Fixed:
    - `key` error in `chips` component when labels are loaded with existing values and NO `id` property
    - Make default placeholder label in `TargetPath` clickable on entire field
    
   Before:
   <img width="696" alt="Screen Shot 2022-10-30 at 14 17 51" src="https://user-images.githubusercontent.com/63646693/198878005-d73b6c97-287d-49e2-84bd-a82ad949d68c.png">
   <img width="775" alt="Screen Shot 2022-10-30 at 14 18 37" src="https://user-images.githubusercontent.com/63646693/198878037-756e91cc-aa08-4e21-acaa-605d1a05c03b.png">
    
   After:
   <img width="571" alt="Screen Shot 2022-10-30 at 14 18 57" src="https://user-images.githubusercontent.com/63646693/198878051-d1324783-8a20-4e7f-b0a5-3fb9b73d84a5.png">
