### PR TITLE
Fix [UI] Trimmed tooltips of dataset labels

### DIFF
--- a/src/lib/scss/variables.scss
+++ b/src/lib/scss/variables.scss
@@ -5,7 +5,6 @@ $leftRowOffset: 49px;
 $mainBorderRadius: 4px;
 $modalBorderRadius: 8px;
 
-$navbarWidth: 245px;
 $navbarTogglerWidth: 35px;
 
 $headerHeight: 64px;


### PR DESCRIPTION
- **Dataset**: Trimmed tooltips of dataset labels
   Jira: https://jira.iguazeng.com/browse/ML-2690
  
   After:
   ![image](https://user-images.githubusercontent.com/78905712/202700318-0044e93c-e8a8-4da2-9438-f803d69c754c.png)