### PR TITLE
Fix [UI] redundant tooltips in "Create New" dropdown `1.2.1`

### DIFF
--- a/src/lib/elements/SelectOption/SelectOption.js
+++ b/src/lib/elements/SelectOption/SelectOption.js
@@ -59,7 +59,7 @@ const SelectOption = ({ item, name, onClick, multiple, selectedId, withSelectedI
             </span>
           )}
           {item.status && <span className={`state-${item.status}-job status`} />}
-          <Tooltip template={<TextTooltipTemplate text={item.label} />}><span>{item.label}</span></Tooltip>
+          <span>{item.label}</span>
         </div>
         {withSelectedIcon && item.id === selectedId && <Checkmark className="checkmark" />}
       </div>


### PR DESCRIPTION
- **UI**: redundant tooltips in "Create New" dropdown
   Backported to `1.2.1` from #96 
   Jira: https://jira.iguazeng.com/browse/ML-3057