### PR TITLE
Fix [Combobox] Validation doesn't work correctly

### DIFF
--- a/src/lib/components/FormCombobox/FormCombobox.js
+++ b/src/lib/components/FormCombobox/FormCombobox.js
@@ -264,7 +264,9 @@ const FormCombobox = ({
   }, [input, onBlur, onFocus, showSelectDropdown])
 
   const validateField = (value, allValues) => {
-    const valueToValidate = value.split(selectValue.id)[1] ?? ''
+    const valueToValidate = value.startsWith(selectValue.id)
+      ? value.substring(selectValue.id.length)
+      : value ?? ''
     let validationError = null
 
     if (!isEmpty(validationRules)) {


### PR DESCRIPTION
- **Combobox**: Validation doesn't work correctly
   If the string contains the same value as selected in the dropdown, then the validation did not show the correct message; instead, it showed "The field is required."
   Jira: [ML-3871](https://jira.iguazeng.com/browse/ML-3871)

   Before:
   ![image](https://github.com/iguazio/dashboard-react-controls/assets/25711177/66834f13-940d-485e-891e-50c87723cc2e)
   After:
   ![image](https://github.com/iguazio/dashboard-react-controls/assets/25711177/5daab67b-f7c7-456e-a9f6-23ee308e4ef8)
