### PR TITLE
Fix [Batch run] No validation for a negative CPU value during setting the resources in Batch Run

### DIFF
--- a/src/lib/components/FormInput/FormInput.js
+++ b/src/lib/components/FormInput/FormInput.js
@@ -425,7 +425,7 @@ FormInput.propTypes = {
   pattern: PropTypes.string,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
-  step: PropTypes.string,
+  step: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   suggestionList: PropTypes.arrayOf(PropTypes.string),
   tip: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   type: PropTypes.string,

--- a/src/lib/scss/common.scss
+++ b/src/lib/scss/common.scss
@@ -139,6 +139,7 @@ textarea {
     min-height: $tableHeaderHeight;
     border-bottom: $primaryBorder;
     background-color: $white;
+    padding: 5px 0;
 
     &:not(.no-hover):hover {
       background-color: $alabaster;
@@ -307,7 +308,8 @@ textarea {
   }
 
   &_left {
-    &::before, &::after {
+    &::before,
+    &::after {
       right: 15px;
     }
   }


### PR DESCRIPTION
- **Batch run**: No validation for a negative CPU value during setting the resources in Batch Run
   Jira: [ML-4308](https://jira.iguazeng.com/browse/ML-4308)
   
   Before:
   ![image](https://github.com/mlrun/ui/assets/63646693/3a0f57b6-06de-4f1f-b65d-9d27d0b26ba6)
   
   After:
   <img width="412" alt="Screenshot 2023-08-06 at 11 39 01" src="https://github.com/mlrun/ui/assets/63646693/97c575d7-3977-48a7-b98b-9a75464eb95f">
