### PR TITLE
Fix [ML Functions] Capital letters on function name gives error

### DIFF
--- a/src/lib/utils/validation.util.js
+++ b/src/lib/utils/validation.util.js
@@ -182,7 +182,9 @@ const generateRule = {
     return {
       name: 'validCharactersWithPrefix',
       label: ValidationConstants.VALID_CHARACTERS + ': ' + convertToLabel(chars),
-      pattern: new RegExp('^([' + convertToPattern(chars) + ']+\/)?[' + convertToPattern(chars) + ']+$')
+      pattern: new RegExp(
+        '^([' + convertToPattern(chars) + ']+/)?[' + convertToPattern(chars) + ']+$'
+      )
     }
   },
   noConsecutiveCharacters: (chars) => {
@@ -295,8 +297,8 @@ const validationRules = {
   },
   function: {
     name: [
-      generateRule.validCharacters('a-z A-Z 0-9 - .'),
-      generateRule.beginEndWith('a-z A-Z 0-9'),
+      generateRule.validCharacters('a-z 0-9 - .'),
+      generateRule.beginEndWith('a-z 0-9'),
       generateRule.length({ max: 63 }),
       generateRule.required()
     ]


### PR DESCRIPTION
- **ML Functions**: Capital letters on function name gives error
   Jira: [ML-4533](https://jira.iguazeng.com/browse/ML-4533)
   
   Before:
   <img width="505" alt="Screenshot 2023-09-05 at 16 48 09" src="https://github.com/iguazio/dashboard-react-controls/assets/63646693/c7bff7f2-a761-42eb-8ff6-7e4c0286ad32">
   <img width="880" alt="Screenshot 2023-09-05 at 16 49 39" src="https://github.com/iguazio/dashboard-react-controls/assets/63646693/036aca9f-7808-4332-93d2-67cea186c774">
   
   After:
   <img width="513" alt="Screenshot 2023-09-05 at 16 52 41" src="https://github.com/iguazio/dashboard-react-controls/assets/63646693/f65387c1-be67-4df4-8ab0-e9d2bc20b594">

