### PR TITLE
Fix [Batch Run] Steps style is broken on Batch Run not full screen

### DIFF
--- a/dist/components/Button/Button.js
+++ b/dist/components/Button/Button.js
@@ -62,7 +62,7 @@ var Button = /*#__PURE__*/(0, _react.forwardRef)(function (_ref, ref) {
       children: /*#__PURE__*/(0, _jsxRuntime.jsx)("span", {
         children: label
       })
-    }) : /*#__PURE__*/(0, _jsxRuntime.jsx)("span", {
+    }) : /*#__PURE__*/(0, _jsxRuntime.jsx)("div", {
       children: label
     })]
   }));

--- a/dist/components/Wizard/WizardSteps/WizardSteps.scss
+++ b/dist/components/Wizard/WizardSteps/WizardSteps.scss
@@ -48,6 +48,10 @@
         border-color: $malibu;
         color: $malibu;
         background-color: inherit;
+
+        & + * {
+          display: block;
+        }
       }
 
       &.wizard-steps__item_active {

--- a/src/lib/components/Button/Button.js
+++ b/src/lib/components/Button/Button.js
@@ -38,7 +38,7 @@ const Button = forwardRef(
             <span>{label}</span>
           </Tooltip>
         ) : (
-          <span>{label}</span>
+          <div>{label}</div>
         )}
       </button>
     )

--- a/src/lib/components/Wizard/WizardSteps/WizardSteps.scss
+++ b/src/lib/components/Wizard/WizardSteps/WizardSteps.scss
@@ -48,6 +48,10 @@
         border-color: $malibu;
         color: $malibu;
         background-color: inherit;
+
+        & + * {
+          display: block;
+        }
       }
 
       &.wizard-steps__item_active {


### PR DESCRIPTION
- **Batch Run**: Steps style is broken on Batch Run not full screen
   Jira: [ML-5289](https://jira.iguazeng.com/browse/ML-5289)
   
   Before:
   <img width="1092" alt="Screenshot 2023-12-13 at 20 47 38" src="https://github.com/iguazio/dashboard-react-controls/assets/63646693/cdcdafd0-67db-44a5-a23c-9df834250317">

   After:
   <img width="1092" alt="Screenshot 2023-12-13 at 20 47 19" src="https://github.com/iguazio/dashboard-react-controls/assets/63646693/26c7e0bc-7f3b-4bef-a9c9-789e6616ca50">
