### PR TITLE
Fix [Node Selector] Different naming convention for Node Selector key between Nuclio and Project setting/ Mlrun func

### DIFF
--- a/src/lib/utils/validation.util.js
+++ b/src/lib/utils/validation.util.js
@@ -392,7 +392,7 @@ const validationRules = {
     }
   },
   nodeSelectors: {
-    key: commonRules.k8sLabels.key,
+    key: commonRules.prefixedQualifiedName,
     value: commonRules.k8sLabels.value
   },
   environmentVariables: {


### PR DESCRIPTION
- **Node Selector**: Different naming convention for Node Selector key between Nuclio and Project setting/ Mlrun func
   Jira: [ML-6303](https://iguazio.atlassian.net/browse/ML-6303)

[ML-6303]: https://iguazio.atlassian.net/browse/ML-6303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ