### PR TITLE
Create a new dist version `2.0.4`

### DIFF
--- a/commit_message
+++ b/commit_message
@@ -1,6 +1,6 @@
 
 
-Create a new dist version 2.0.3
+Create a new dist version 2.0.4
 
 Collecting:
-- Impl [Functions] Add 'Application' type info (#268)
+- Fix [Node Selector] Different naming convention for Node Selector key between Nuclio and Project setting/ Mlrun func (#270)

--- a/dist/utils/validation.util.js
+++ b/dist/utils/validation.util.js
@@ -332,7 +332,7 @@ const validationRules = {
     }
   },
   nodeSelectors: {
-    key: commonRules.k8sLabels.key,
+    key: commonRules.prefixedQualifiedName,
     value: commonRules.k8sLabels.value
   },
   environmentVariables: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "iguazio.dashboard-react-controls",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Collection of resources (such as CSS styles, fonts and images) and ReactJS 17.x components to share among different Iguazio React repos.",
     "main": "dist/index.js",
     "module": "dist/index.js",


### PR DESCRIPTION
Collecting:
- Fix [Node Selector] Different naming convention for Node Selector key between Nuclio and Project setting/ Mlrun func (#270)