### PR TITLE
Fix [Wizard] batch run - back/next buttons does not look like "button"

### DIFF
--- a/src/lib/components/Button/Button.js
+++ b/src/lib/components/Button/Button.js
@@ -32,6 +32,7 @@ const Button = forwardRef(
       className = '',
       density = 'normal',
       icon,
+      iconPosition = 'left',
       id = 'btn',
       label = 'Button',
       tooltip = '',
@@ -44,14 +45,15 @@ const Button = forwardRef(
 
     return (
       <button {...restProps} className={buttonClassName} ref={ref} data-testid={id}>
-        {icon}
+        {icon && iconPosition === 'left' && icon}
         {tooltip ? (
           <Tooltip template={<TextTooltipTemplate text={tooltip} />}>
-            {label && <div>{label}</div>}
+            {label && <span>{label}</span>}
           </Tooltip>
         ) : (
-          label && <div>{label}</div>
+          label && <span>{label}</span>
         )}
+        {icon && iconPosition === 'right' && icon}
       </button>
     )
   }

--- a/src/lib/components/Wizard/Wizard.js
+++ b/src/lib/components/Wizard/Wizard.js
@@ -23,8 +23,10 @@ import Button from '../Button/Button'
 import Modal from '../Modal/Modal'
 import WizardSteps from './WizardSteps/WizardSteps'
 
-import { LABEL_BUTTON, MODAL_MD } from '../../constants'
+import { MODAL_MD, TERTIARY_BUTTON } from '../../constants'
 import { MODAL_SIZES, WIZARD_STEPS_CONFIG } from '../../types'
+
+import { ReactComponent as Back } from '../../images/back-arrow.svg'
 
 import './Wizard.scss'
 
@@ -127,11 +129,13 @@ const Wizard = ({
       defaultActions.push(
         <Button
           id="wizard-btn-back"
+          icon={<Back />}
+          className="wizard-form__back-button"
           onClick={goToPreviousStep}
           disabled={activeStepNumber === 0}
           label="Back"
           type="button"
-          variant={LABEL_BUTTON}
+          variant={TERTIARY_BUTTON}
         />
       )
     }
@@ -139,11 +143,14 @@ const Wizard = ({
     defaultActions.push(
       <Button
         id="wizard-btn-next"
+        icon={<Back />}
+        iconPosition="right"
+        className="wizard-form__next-button"
         disabled={stepConfig?.nextIsDisabled || isLastStep}
         onClick={goToNextStep}
-        label={'Next'}
+        label="Next"
         type="button"
-        variant={LABEL_BUTTON}
+        variant={TERTIARY_BUTTON}
       />
     )
 

--- a/src/lib/components/Wizard/Wizard.scss
+++ b/src/lib/components/Wizard/Wizard.scss
@@ -37,4 +37,17 @@
       height: 100%;
     }
   }
+
+  &__back-button,
+  &__next-button {
+    svg {
+      width: 14px;
+    }
+  }
+
+  &__next-button {
+    svg {
+      rotate: 180deg;
+    }
+  }
 }


### PR DESCRIPTION
- **Wizard**: Batch run - back/next buttons does not look like "button"
   Jira: https://iguazio.atlassian.net/browse/ML-9222
   
   Before:
   <img width="518" alt="Screenshot 2025-02-06 at 16 59 07" src="https://github.com/user-attachments/assets/5df2302c-c491-4757-960a-53c1b96baafc" />

   After:
   <img width="469" alt="Screenshot 2025-02-06 at 17 01 19" src="https://github.com/user-attachments/assets/f4a50cc1-aff2-489c-9b93-3bc5d37fe1dd" />


   
   