### PR TITLE
Fix [Artifacts] Path dropdown doesn't close when clicking outside the field `1.9.x`

### DIFF
--- a/src/lib/components/FormCombobox/FormCombobox.js
+++ b/src/lib/components/FormCombobox/FormCombobox.js
@@ -362,7 +362,7 @@ const FormCombobox = ({
                   }}
                   className="form-field-combobox__dropdown form-field-combobox__dropdown-select"
                 >
-                  <ul className="form-field-combobox__dropdown-list">
+                  <ul className="form-field-combobox__dropdown-list" ref={suggestionListRef}>
                     {selectOptions.map(option => {
                       if (!option.hidden) {
                         const selectOptionClassNames = classnames(


### PR DESCRIPTION
- **Artifacts**: Path dropdown doesn't close when clicking outside the field
   Backported to `1.9.x` from #392 
   Jira: https://iguazio.atlassian.net/browse/ML-9861