### PR TITLE
Create a new dist version `2.2.22-1.9.x`

### DIFF
--- a/dist/components/FormCombobox/FormCombobox.js
+++ b/dist/components/FormCombobox/FormCombobox.js
@@ -325,6 +325,7 @@ const FormCombobox = _ref => {
               className: "form-field-combobox__dropdown form-field-combobox__dropdown-select",
               children: /*#__PURE__*/(0, _jsxRuntime.jsx)("ul", {
                 className: "form-field-combobox__dropdown-list",
+                ref: suggestionListRef,
                 children: selectOptions.map(option => {
                   if (!option.hidden) {
                     const selectOptionClassNames = (0, _classnames.default)('form-field-combobox__dropdown-list-option', option.className);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "iguazio.dashboard-react-controls",
-    "version": "2.2.21",
+    "version": "2.2.22-1.9.x",
     "description": "Collection of resources (such as CSS styles, fonts and images) and ReactJS 17.x components to share among different Iguazio React repos.",
     "main": "dist/index.js",
     "module": "dist/index.js",


### PR DESCRIPTION
**Collecting**:
- Fix [Artifacts] Path dropdown doesn't close when clicking outside the field `1.9.x` (#393)

