### PR TITLE
Fix [Monitoring app] Date picker selection not preserved between pages `1.10.x`

### DIFF
--- a/src/lib/elements/TableLinkCell/TableLinkCell.jsx
+++ b/src/lib/elements/TableLinkCell/TableLinkCell.jsx
@@ -55,7 +55,7 @@ const TableLinkCell = ({
     <td data-testid={cellData.headerId} className={tableCellClassNames}>
       {cellData.linkIsExternal ? (
         <span className="data-ellipsis">
-          <a href={link} className="link" target="blank">
+          <a href={link} className="link" target="_top">
             <Tooltip
               className={itemNameClassNames}
               template={<TextTooltipTemplate text={cellData.tooltip || cellData.value || ''} />}


### PR DESCRIPTION
- **Monitoring app**: Date picker selection not preserved between pages
   Backported to `1.10.x` from https://github.com/iguazio/dashboard-react-controls/pull/449
   Jira: https://iguazio.atlassian.net/browse/ML-11385