### PR TITLE
[FIX] Pipelines table components layout

### DIFF
--- a/src/lib/components/FormToggle/FormToggle.jsx
+++ b/src/lib/components/FormToggle/FormToggle.jsx
@@ -35,7 +35,6 @@ const FormToggle = ({
   ...inputProps
 }) => {
   const formFieldClassNames = classnames(
-    'test',
     'form-field-toggle',
     'form-field__wrapper',
     density && `form-field__wrapper-${density}`,

--- a/src/lib/components/FormToggle/formToggle.scss
+++ b/src/lib/components/FormToggle/formToggle.scss
@@ -13,6 +13,7 @@
   &__label {
     display: flex;
     align-items: center;
+    white-space: nowrap
   }
 
   &__toggle-wrapper {

--- a/src/lib/components/FormToggle/formToggle.scss
+++ b/src/lib/components/FormToggle/formToggle.scss
@@ -13,7 +13,7 @@
   &__label {
     display: flex;
     align-items: center;
-    white-space: nowrap
+    white-space: nowrap;
   }
 
   &__toggle-wrapper {


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://iguazio.atlassian.net/browse/ML-12118
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
