### PR TITLE
[CI] Fix publish workflow version bump ordering and tag caching

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,19 +48,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build package
+        run: npm run build
+
       - name: Bump Package version
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm version ${{ github.event.inputs.version }}
+          NEW_VERSION=$(npm version ${{ github.event.inputs.version }})
+          echo "RELEASE_TAG=$NEW_VERSION" >> "$GITHUB_ENV"
           git push
-          git push --tags
-
-      - name: Set release tag
-        run: echo "RELEASE_TAG=v$(npm pkg get version | tr -d '\"')" >> "$GITHUB_ENV"
-
-      - name: Build package
-        run: npm run build
+          git push origin "$NEW_VERSION"
 
       - name: Publish to npm
         id: publish


### PR DESCRIPTION
  ## 📝 Description
  Fixes the publish workflow to avoid pushing a version bump to git before the build succeeds. Also removes a redundant step that re-read the version from `package.json` when it was already available in memory.

  ---
  ## 🛠️ Changes Made
  - Moved the "Build package" step **before** the version bump so that a failed build doesn't leave a bumped-but-unpublished version in git
  - Removed the separate "Set release tag" step — `RELEASE_TAG` is now set directly from the `npm version` output in the bump step
  - Replaced `git push --tags` (which pushes **all** local tags) with `git push origin "$NEW_VERSION"` to push only the relevant tag
  ---
  ## ✅ Checklist
  - [x] I have given the PR a well-structured title describing the domain and the specific change that was made
  - [ ] I tested the changes in the browser (locally or via preview build)
  - [x] I confirmed that existing tests pass
  - [ ] I added or updated unit / integration tests (if needed)
  - [x] I checked that this change doesn't introduce new console warnings or lint / formatting errors
  - [ ] I updated the relevant Jira ticket with the appropriate details and status
  ---
  ## 🔗 References
  - Related ticket / issue:
  - Figma / design spec: N/A
  - Documentation:
  ---
  ## 🚨 Potentially Breaking Changes
  - [ ] Yes
  - [x] No
  ## 🔍 Additional Notes
  - The build now runs before `npm version`, so if the build fails the git history and npm registry remain untouched and the workflow can be safely re-run.
  - `git push --tags` was replaced with a scoped push to avoid accidentally pushing unrelated local tags.
  ---
  ## 📸 Screenshots / Demos
  N/A — CI-only change.
