### PR TITLE
[CI] Fix publish workflow version bump ordering and tag handling

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,19 +48,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build package
+        run: npm run build
+
       - name: Bump Package version
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          npm version ${{ github.event.inputs.version }}
+          NEW_VERSION=$(npm version ${{ github.event.inputs.version }})
+          echo "RELEASE_TAG=$NEW_VERSION" >> "$GITHUB_ENV"
           git push
-          git push --tags
-
-      - name: Set release tag
-        run: echo "RELEASE_TAG=v$(npm pkg get version | tr -d '\"')" >> "$GITHUB_ENV"
-
-      - name: Build package
-        run: npm run build
+          git push origin "$NEW_VERSION"
 
       - name: Publish to npm
         id: publish

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store


### PR DESCRIPTION
 ## 📝 Description
  Fixes the publish workflow to build **before** bumping the version, so a failed build doesn't leave a bumped-but-unpublished version in git. Also removes a redundant step and scopes the tag push to only the 
  relevant release tag.

  ---
  ## 🛠️ Changes Made
  - Moved "Build package" step before the version bump so build failures don't pollute git history
  - Removed the separate "Set release tag" step — `RELEASE_TAG` is now set directly from the `npm version` output
  - Replaced `git push --tags` with `git push origin "$NEW_VERSION"` to push only the newly created tag
  - Added `/dist` to `.gitignore` to prevent build artifacts from dirtying the git working directory (which caused `npm version` to fail)
  ---
  ## ✅ Checklist
  - [x] I have given the PR a well-structured title describing the domain and the specific change that was made
  - [ ] I tested the changes in the browser (locally or via preview build)
  - [x] I confirmed that existing tests pass
  - [ ] I added or updated unit / integration tests (if needed)
  - [x] I checked that this change doesn't introduce new console warnings or lint / formatting errors
  - [ ] I updated the relevant Jira ticket with the appropriate details and status
  ---
  ## 🔗 References
  - Related ticket / issue:
  - Figma / design spec: N/A
  - Documentation:
  ---
  ## 🚨 Potentially Breaking Changes
  - [ ] Yes
  - [x] No
  ## 🔍 Additional Notes
  - Previously, if the build or npm publish failed after the version bump, re-running the workflow would bump the version **again**, creating a version gap. The new ordering avoids this.
  - `/dist` was not in `.gitignore`, causing `npm version` to error with "Git working directory not clean" when the build ran first.
  ---
  ## 📸 Screenshots / Demos
  N/A — CI-only change.