### PR TITLE
[FIX] vulnrabilities

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,14 +62,14 @@ jobs:
 
       - name: Publish to npm
         id: publish
-        uses: JS-DevTools/npm-publish@v4
+        uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
 
       - name: Create GitHub Release
         if: steps.publish.outcome == 'success'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: ${{ env.RELEASE_TAG }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+.npm-cache
 /.pnp
 .pnp.js
 .idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
                 "@reduxjs/toolkit": "^2.8.2",
-                "@storybook/addon-actions": "^8.6.15",
-                "@storybook/addon-essentials": "^8.6.15",
-                "@storybook/addon-interactions": "^8.6.15",
-                "@storybook/addon-links": "^8.6.15",
-                "@storybook/builder-webpack5": "^8.6.15",
+                "@storybook/addon-actions": "^8.6.17",
+                "@storybook/addon-essentials": "^8.6.17",
+                "@storybook/addon-interactions": "^8.6.17",
+                "@storybook/addon-links": "^8.6.17",
+                "@storybook/builder-webpack5": "^8.6.17",
                 "@storybook/manager-webpack5": "^6.5.16",
-                "@storybook/react": "^8.6.15",
+                "@storybook/react": "^8.6.17",
                 "@storybook/testing-library": "0.2.2",
                 "@types/react": "18.3.1",
                 "@types/react-dom": "18.3.1",
@@ -2825,6 +2825,436 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@jsonjoy.com/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/buffers": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+            "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/codegen": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+            "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-core": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.10.tgz",
+            "integrity": "sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.56.10",
+                "@jsonjoy.com/fs-node-utils": "4.56.10",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-fsa": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.10.tgz",
+            "integrity": "sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.56.10",
+                "@jsonjoy.com/fs-node-builtins": "4.56.10",
+                "@jsonjoy.com/fs-node-utils": "4.56.10",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.10.tgz",
+            "integrity": "sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.56.10",
+                "@jsonjoy.com/fs-node-builtins": "4.56.10",
+                "@jsonjoy.com/fs-node-utils": "4.56.10",
+                "@jsonjoy.com/fs-print": "4.56.10",
+                "@jsonjoy.com/fs-snapshot": "4.56.10",
+                "glob-to-regex.js": "^1.0.0",
+                "thingies": "^2.5.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-builtins": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.10.tgz",
+            "integrity": "sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.10.tgz",
+            "integrity": "sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-fsa": "4.56.10",
+                "@jsonjoy.com/fs-node-builtins": "4.56.10",
+                "@jsonjoy.com/fs-node-utils": "4.56.10"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-node-utils": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.10.tgz",
+            "integrity": "sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-builtins": "4.56.10"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-print": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.10.tgz",
+            "integrity": "sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-node-utils": "4.56.10",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.10.tgz",
+            "integrity": "sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^17.65.0",
+                "@jsonjoy.com/fs-node-utils": "4.56.10",
+                "@jsonjoy.com/json-pack": "^17.65.0",
+                "@jsonjoy.com/util": "^17.65.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+            "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+            "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+            "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "17.67.0",
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0",
+                "@jsonjoy.com/json-pointer": "17.67.0",
+                "@jsonjoy.com/util": "17.67.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+            "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/util": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+            "version": "17.67.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+            "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "17.67.0",
+                "@jsonjoy.com/codegen": "17.67.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pack": {
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+            "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/base64": "^1.1.2",
+                "@jsonjoy.com/buffers": "^1.2.0",
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/json-pointer": "^1.0.2",
+                "@jsonjoy.com/util": "^1.9.0",
+                "hyperdyperid": "^1.2.0",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/json-pointer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+            "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/codegen": "^1.0.0",
+                "@jsonjoy.com/util": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/util": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+            "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/buffers": "^1.0.0",
+                "@jsonjoy.com/codegen": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+            "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
         "node_modules/@mdx-js/react": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
@@ -3614,9 +4044,9 @@
             "license": "MIT"
         },
         "node_modules/@storybook/addon-actions": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.15.tgz",
-            "integrity": "sha512-zc600PBJqP9hCyRY5escKgKf6Zt9kdNZfm+Jwb46k5/NMSO4tNVeOPGBFxW9kSsIYk8j55sNske+Yh60G+8bcw==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-8.6.17.tgz",
+            "integrity": "sha512-/G3Y7WIzGHMtKT6r3KCqgY/pAzfMhNHvBoRWoPfxMa27GiwmUaJlbfRPSReK/jGz6ye0Uwqix+NFbRXKiTqOJQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3631,13 +4061,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-backgrounds": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.15.tgz",
-            "integrity": "sha512-W36uEzMWPO/K3+8vV1R/GozdaFrIix0qqmxX0qoAT6/o4+zqHiloZkTF+2iuUTx/VmuztLcAoSaPDh8UPy3Q+g==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-backgrounds/-/addon-backgrounds-8.6.17.tgz",
+            "integrity": "sha512-oh7jEQUt8WhH7cBm0jsJ1dujyaujM5rVS5IXJmDgdFJ8l0pqGzOUDmgkBVX147Uo5W1U47Sx+hA69lg6TKPOMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3650,13 +4080,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-controls": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.6.15.tgz",
-            "integrity": "sha512-CgV8WqGxQrqSKs1a/Y1v4mrsBJXGFmO5u4kvdhPbftRVfln11W4Hvc1SFmgXwGvmcwekAKH79Uwwkjhj3l6gzA==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-controls/-/addon-controls-8.6.17.tgz",
+            "integrity": "sha512-kquUfiJyJMh8IHviTIz1A4UKqqNfvqrYFku9D3UukqkTriM1ngDOb9nryaJcUNTkco5JmIuGjYEJisva+u13lw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3669,20 +4099,20 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-docs": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.15.tgz",
-            "integrity": "sha512-Nm5LlxwAmGQRkCUY36FhtCLz21C+5XlydF7/bkBOHsf08p2xR5MNLMSPrIhte/PY7ne9viNUCm1d3d3LiWnkKg==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-8.6.17.tgz",
+            "integrity": "sha512-zvcSzoYvaZO4l9NxsviDr5vmuq8GVnH4Ap0v+5sSTq192yevm/iQcRnkWYBD9E/Lg5GBeyE+Ml2vjEOK+EPBEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@mdx-js/react": "^3.0.0",
-                "@storybook/blocks": "8.6.15",
-                "@storybook/csf-plugin": "8.6.15",
-                "@storybook/react-dom-shim": "8.6.15",
+                "@storybook/blocks": "8.6.17",
+                "@storybook/csf-plugin": "8.6.17",
+                "@storybook/react-dom-shim": "8.6.17",
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "ts-dedent": "^2.0.0"
@@ -3692,25 +4122,25 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-essentials": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.15.tgz",
-            "integrity": "sha512-BIcE/7t5WXDXs4+zycm7MLNPHA2219ImkKO70IH7uxGM4cm7jDuJ5v0crkAvNeeRVsZixT2P2L9EfUfi1cFCQg==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-essentials/-/addon-essentials-8.6.17.tgz",
+            "integrity": "sha512-nyp2RUxWGpD+xhGWOo221kHOY6cZlgXsV1F11sn7WxkH+yA7YHhLLYlIPHmNKKH+hdxN0rnlcpwjbr21u0Katg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@storybook/addon-actions": "8.6.15",
-                "@storybook/addon-backgrounds": "8.6.15",
-                "@storybook/addon-controls": "8.6.15",
-                "@storybook/addon-docs": "8.6.15",
-                "@storybook/addon-highlight": "8.6.15",
-                "@storybook/addon-measure": "8.6.15",
-                "@storybook/addon-outline": "8.6.15",
-                "@storybook/addon-toolbars": "8.6.15",
-                "@storybook/addon-viewport": "8.6.15",
+                "@storybook/addon-actions": "8.6.17",
+                "@storybook/addon-backgrounds": "8.6.17",
+                "@storybook/addon-controls": "8.6.17",
+                "@storybook/addon-docs": "8.6.17",
+                "@storybook/addon-highlight": "8.6.17",
+                "@storybook/addon-measure": "8.6.17",
+                "@storybook/addon-outline": "8.6.17",
+                "@storybook/addon-toolbars": "8.6.17",
+                "@storybook/addon-viewport": "8.6.17",
                 "ts-dedent": "^2.0.0"
             },
             "funding": {
@@ -3718,13 +4148,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-highlight": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.15.tgz",
-            "integrity": "sha512-lOu44QTVw5nR8kzag0ukxWnLq48oy2MqMUDuMVFQWPBKX8ayhmgl2OiEcvAOVNsieTHrr2W4CkP7FFvF4D0vlg==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-highlight/-/addon-highlight-8.6.17.tgz",
+            "integrity": "sha512-Tf7DxksSg+DqH0a0rLIpB5g9bJBUHcqmEGeYGX7EPQrXBpQAtFXz/XdzuD8eYDlPC1r42iQQw4w+CQnXJCOHFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3735,19 +4165,19 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-interactions": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-8.6.15.tgz",
-            "integrity": "sha512-9qgu7jbPjzFm44UF57D6puK+/86maE26gY+06Thz1NpTBCjVIl2fTZ/CA00iXb5+12f3JmSF0w3XEjsqcrzd3w==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-interactions/-/addon-interactions-8.6.17.tgz",
+            "integrity": "sha512-aj0jC5kMnYYHBofAZrPAfZf2/j9BXMIwMJ9dLdc7Qwxsvig3txWlSx7Wh+szaR2jDz/areh1rZyrwiPHyxxQ4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@storybook/global": "^5.0.0",
-                "@storybook/instrumenter": "8.6.15",
-                "@storybook/test": "8.6.15",
+                "@storybook/instrumenter": "8.6.17",
+                "@storybook/test": "8.6.17",
                 "polished": "^4.2.2",
                 "ts-dedent": "^2.2.0"
             },
@@ -3756,13 +4186,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-links": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-8.6.15.tgz",
-            "integrity": "sha512-abRWnDPBTwnj6sQYfAjUnYCNuUQbrVLLOyuormbDUqOcvZ+OqehNYo4BKXx0/lz61h0A2dOD1IuDo40uWyYVFQ==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-8.6.17.tgz",
+            "integrity": "sha512-ch1GgXILEmekf81nUvmre3xyhlg5zDibRxm8+psPqj7GqzWBI5l4kAiha0XOBWGz6vQEL5xCvN/rr8rfA9kWdQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3775,7 +4205,7 @@
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             },
             "peerDependenciesMeta": {
                 "react": {
@@ -3784,9 +4214,9 @@
             }
         },
         "node_modules/@storybook/addon-measure": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.6.15.tgz",
-            "integrity": "sha512-F78fJlmuXMulTphFp9Iqx7I1GsbmNLboChnW/VqR6nRZx5o9cdGjc8IaEyXVFXZ7k1pnSvdaP5ndFmzkcPxQdg==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-measure/-/addon-measure-8.6.17.tgz",
+            "integrity": "sha512-OFGmCrz9MTWfxa0t2GP+633VXZS7W3ahIM5bRmCTeG+jF/gdiVw3S2Adq7YiIZw+nROW9VtHBjuWGvy2miZxcQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3798,13 +4228,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-outline": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.6.15.tgz",
-            "integrity": "sha512-rpGRLajsjBdpbggPmdNZbftF68zQwsYLosu7YiUSBaR4dm+gQ+7m5nLLI/MjZDHbt2nJRW94yXpn7dUw2CDF6g==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-outline/-/addon-outline-8.6.17.tgz",
+            "integrity": "sha512-UfFThgImS8cuv9Mts5JozGO2/SgjU61uKZxn7w+YpJQu0r2UAF56ZBBMZF/Ur5IC4HaoqDWF5DksMlFqMHPBsw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3816,13 +4246,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-toolbars": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.6.15.tgz",
-            "integrity": "sha512-NfHAbOOu5qI9SQq6jJr2VfinaZpHrmz3bavBeUppxCxM+zfPuNudK8MlMOOuyPBPAoUqcDSoKZgNfCkOBQcyGg==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-toolbars/-/addon-toolbars-8.6.17.tgz",
+            "integrity": "sha512-LoWtnMVQJWivAu+SZdgYIsaiEqIq0mZ8Ses2xSwLnQZxndCakyqPYv/7YcdLDJaX5f8DpjPvSzJ77oa75oKgFw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -3830,13 +4260,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addon-viewport": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.15.tgz",
-            "integrity": "sha512-ylTK4sehAeVTwcYMZyisyP3xX+m43NjJrQHKc3DAII3Z3RFqTv9l6CUMogM2/8mysTzoo8xYVtQB6hX7zB8Dew==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/addon-viewport/-/addon-viewport-8.6.17.tgz",
+            "integrity": "sha512-gVUtbFQq/mpD5CFOqXGAu5hUpGm/t5G/psg3YsTjnaRBd18dJZ/+//HzZVbX9aEW8t5qTJeJcEYaF5463BVfNA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3847,7 +4277,7 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/addons": {
@@ -3913,9 +4343,9 @@
             }
         },
         "node_modules/@storybook/blocks": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.15.tgz",
-            "integrity": "sha512-nc5jQkvPo0EirteHsrmcx9on/0lGQ8F4lUNky7kN2I5WM8Frr3cPTeRoAvzjUkOwrqt/vm3g+T4zSbmDq/OEDA==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/blocks/-/blocks-8.6.17.tgz",
+            "integrity": "sha512-zuYHH+0egovMrjWRKwOtgVGbz6KALGowPSWBzQ8deTBu6IXfkz6Ce1hRLJPn5S6/jDqqr9xx8vuAiypnRQ98tA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3929,7 +4359,7 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             },
             "peerDependenciesMeta": {
                 "react": {
@@ -3941,13 +4371,13 @@
             }
         },
         "node_modules/@storybook/builder-webpack5": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-8.6.15.tgz",
-            "integrity": "sha512-4UZAm0t8CxVMUjkTzLaBoCKG3Bqg+lEKxrPrTGRddLlVCB8olv23C3/MW1aQJfzde9ze6ofllkn97r1tVG6ipQ==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/builder-webpack5/-/builder-webpack5-8.6.17.tgz",
+            "integrity": "sha512-QK0HuTLn/doWQNu/tBC8tP0DrQLqyZk/IeYaxYh43G3igsYHI+yTIG//lHLSRFqkJM6tFT2SIJO8xExE/MCMGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@storybook/core-webpack": "8.6.15",
+                "@storybook/core-webpack": "8.6.17",
                 "@types/semver": "^7.3.4",
                 "browser-assert": "^1.2.1",
                 "case-sensitive-paths-webpack-plugin": "^2.4.0",
@@ -3977,7 +4407,7 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -4092,9 +4522,9 @@
             }
         },
         "node_modules/@storybook/components": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.15.tgz",
-            "integrity": "sha512-+9GVKXPEW8Kl9zvNSTm9+VrJtx/puMZiO7gxCML63nK4aTWJXHQr4t9YUoGammSBM3AV1JglsKm6dBgJEeCoiA==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.17.tgz",
+            "integrity": "sha512-0b8xkkuPCNbM8LTOzyfxuo2KdJCHIfu3+QxWBFllXap0eYNHwVeSxE5KERQ/bk2GDCiRzaUbwH9PeLorxOzJJQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -4417,41 +4847,6 @@
                 "node": ">=0.4.0"
             }
         },
-        "node_modules/@storybook/core-common/node_modules/braces": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@storybook/core-common/node_modules/braces/node_modules/extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extendable": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@storybook/core-common/node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -4528,35 +4923,6 @@
                 "node": ">=4.0"
             }
         },
-        "node_modules/@storybook/core-common/node_modules/fill-range": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-            "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@storybook/core-common/node_modules/fill-range/node_modules/extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-extendable": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@storybook/core-common/node_modules/fork-ts-checker-webpack-plugin": {
             "version": "6.5.3",
             "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz",
@@ -4595,42 +4961,6 @@
                 "vue-template-compiler": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@storybook/core-common/node_modules/is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@storybook/core-common/node_modules/is-number": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-            "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kind-of": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/@storybook/core-common/node_modules/is-number/node_modules/kind-of": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-buffer": "^1.1.5"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@storybook/core-common/node_modules/is-wsl": {
@@ -4755,16 +5085,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/@storybook/core-common/node_modules/serialize-javascript": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
-            }
-        },
         "node_modules/@storybook/core-common/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -4840,20 +5160,6 @@
             },
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/@storybook/core-common/node_modules/to-regex-range": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-            "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/@storybook/core-common/node_modules/watchpack": {
@@ -4972,9 +5278,9 @@
             }
         },
         "node_modules/@storybook/core-webpack": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-8.6.15.tgz",
-            "integrity": "sha512-DZUxsF9KwzUGYzXg8gQ7xnAnLnulh8wkaxEqkVt7xMJ95FLZYCI8o+05tJ3tNUYzjPMTzoAUPL2OD9bb6HcSzw==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-8.6.17.tgz",
+            "integrity": "sha512-q8acHGExmDdqUyzYoPrxp52bUQ3pEskXlcZIETReb3++pATv7zlSghPVA283O9jgj9jYfz9VYyRjW3vqzIzi0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4985,7 +5291,7 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/core/node_modules/@storybook/theming": {
@@ -5014,9 +5320,9 @@
             }
         },
         "node_modules/@storybook/csf-plugin": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.15.tgz",
-            "integrity": "sha512-ZLz/mtOoE1Jj2lE4pK3U7MmYrv5+lot3mGtwxGb832tcABMc97j9O+reCVxZYc7DeFbBuuEdMT9rBL/O3kXYmw==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-8.6.17.tgz",
+            "integrity": "sha512-ouvF/izbKclZxpfnRUkyC5ZVDU7QA0cHhjQnXTDT4F8b0uciQUDw1LosDZy5MXf03BeIDdyBAtzd/ym3wzd+kw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5027,7 +5333,7 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/global": {
@@ -5052,9 +5358,9 @@
             }
         },
         "node_modules/@storybook/instrumenter": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.6.15.tgz",
-            "integrity": "sha512-TvHR/+yyIAOp/1bLulFai2kkhIBtAlBw7J6Jd9DKyInoGhTWNE1G1Y61jD5GWXX29AlwaHfzGUaX5NL1K+FJpg==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/instrumenter/-/instrumenter-8.6.17.tgz",
+            "integrity": "sha512-uPqC0sPY2tYGkEVi1x+L4hvhkTwxT16B/LB8xIXh68co3gR8vY6wVskoBp2tM7LSUGl08U2ksZWxyTo1DaQY5Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5066,13 +5372,13 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/manager-api": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.15.tgz",
-            "integrity": "sha512-ZOFtH821vFcwzECbFYFTKtSVO96Cvwwg45dMh3M/9bZIdN7klsloX7YNKw8OKvwE6XLFLsi2OvsNNcmTW6g88w==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.17.tgz",
+            "integrity": "sha512-sPJytvClNrw5GgKcPletMTxDOAYcTRA8VRt9E+ncKvPSYHtPDqLfGTgWajXmt0hRsiBUN5bOgLS9bmNjNQWhrw==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5141,13 +5447,6 @@
             "version": "16.18.126",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
             "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@storybook/manager-webpack5/node_modules/colorette": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
-            "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
             "dev": true,
             "license": "MIT"
         },
@@ -5220,31 +5519,6 @@
                 "webpack": "^4.0.0 || ^5.0.0"
             }
         },
-        "node_modules/@storybook/manager-webpack5/node_modules/webpack-dev-middleware": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-4.3.0.tgz",
-            "integrity": "sha512-PjwyVY95/bhBh6VUqt6z4THplYcsvQ8YNNBTBM873xLVmw8FLeALn0qurHbs9EmcfhzQis/eoqypSnZeuUz26w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "colorette": "^1.2.2",
-                "mem": "^8.1.1",
-                "memfs": "^3.2.2",
-                "mime-types": "^2.1.30",
-                "range-parser": "^1.2.1",
-                "schema-utils": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= v10.23.3"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/webpack"
-            },
-            "peerDependencies": {
-                "webpack": "^4.0.0 || ^5.0.0"
-            }
-        },
         "node_modules/@storybook/manager-webpack5/node_modules/webpack-virtual-modules": {
             "version": "0.4.6",
             "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.4.6.tgz",
@@ -5271,9 +5545,9 @@
             }
         },
         "node_modules/@storybook/preview-api": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.15.tgz",
-            "integrity": "sha512-oqsp8f7QekB9RzpDqOXZQcPPRXXd/mTsnZSdAAQB/pBVqUpC9h/y5hgovbYnJ6DWXcpODbMwH+wbJHZu5lvm+w==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.17.tgz",
+            "integrity": "sha512-vpTCTkw11wXerYnlG5Q0y4SbFqG9O6GhR0hlYgCn3Z9kcHlNjK/xuwd3h4CvwNXxRNWZGT8qYYCLn5gSSrX6fA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5318,18 +5592,18 @@
             }
         },
         "node_modules/@storybook/react": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.6.15.tgz",
-            "integrity": "sha512-hdnhlJg+YkpPMOw2hvK7+mhdxAbguA+TFTIAzVV9CeUYoHDIZAsgeKVhRmgZGN20NGjRN5ZcwkplAMJnF9v+6w==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/react/-/react-8.6.17.tgz",
+            "integrity": "sha512-yoOzgyZ2VXPJBmvcKS4EVoAf7SJxXbMBcLjWGvmWdDnS+hd7S9cHG/SbgQ+9/vgiLUc+uEuvQjiKrwY3iOA5rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@storybook/components": "8.6.15",
+                "@storybook/components": "8.6.17",
                 "@storybook/global": "^5.0.0",
-                "@storybook/manager-api": "8.6.15",
-                "@storybook/preview-api": "8.6.15",
-                "@storybook/react-dom-shim": "8.6.15",
-                "@storybook/theming": "8.6.15"
+                "@storybook/manager-api": "8.6.17",
+                "@storybook/preview-api": "8.6.17",
+                "@storybook/react-dom-shim": "8.6.17",
+                "@storybook/theming": "8.6.17"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -5339,10 +5613,10 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "@storybook/test": "8.6.15",
+                "@storybook/test": "8.6.17",
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-                "storybook": "^8.6.15",
+                "storybook": "^8.6.17",
                 "typescript": ">= 4.2.x"
             },
             "peerDependenciesMeta": {
@@ -5355,9 +5629,9 @@
             }
         },
         "node_modules/@storybook/react-dom-shim": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.15.tgz",
-            "integrity": "sha512-m2trBmmd4iom1qwrp1F109zjRDc0cPaHYhDQxZR4Qqdz8pYevYJTlipDbH/K4NVB6Rn687RT29OoOPfJh6vkFA==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-8.6.17.tgz",
+            "integrity": "sha512-bHLsR9b/tiwm9lXbN8kp9XlOgkRXeg84UFwXaWBPu3pOO7vRXukk23SQUpLW+HhjKtCJ3xClSi5uMpse5MpkVQ==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5367,13 +5641,13 @@
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
                 "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/react/node_modules/@storybook/theming": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.15.tgz",
-            "integrity": "sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.17.tgz",
+            "integrity": "sha512-IttFvRqozpuzN5MlQEWGOzUA2rZg86688Dyv1d+bjpYcFHtY1X4XyTCGwv1BPTaTsB959oM8R2yoNYWQkABbBA==",
             "dev": true,
             "license": "MIT",
             "funding": {
@@ -5512,14 +5786,14 @@
             }
         },
         "node_modules/@storybook/test": {
-            "version": "8.6.15",
-            "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.6.15.tgz",
-            "integrity": "sha512-EwquDRUDVvWcZds3T2abmB5wSN/Vattal4YtZ6fpBlIUqONV4o/cOBX39cFfQSUCBrIXIjQ6RmapQCHK/PvBYw==",
+            "version": "8.6.17",
+            "resolved": "https://registry.npmjs.org/@storybook/test/-/test-8.6.17.tgz",
+            "integrity": "sha512-VTuCylXGQrFDZXqZ29+yvJ+A4TZ69jG72rLjiic8hI0SOt87AC/8X1NaYvd2NS4TY0G0PwqtxmKeig8qRDrhNg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@storybook/global": "^5.0.0",
-                "@storybook/instrumenter": "8.6.15",
+                "@storybook/instrumenter": "8.6.17",
                 "@testing-library/dom": "10.4.0",
                 "@testing-library/jest-dom": "6.5.0",
                 "@testing-library/user-event": "14.5.2",
@@ -5531,7 +5805,7 @@
                 "url": "https://opencollective.com/storybook"
             },
             "peerDependencies": {
-                "storybook": "^8.6.15"
+                "storybook": "^8.6.17"
             }
         },
         "node_modules/@storybook/testing-library": {
@@ -6925,9 +7199,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -6987,9 +7261,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7032,9 +7306,9 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7191,16 +7465,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
             "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/arr-flatten": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7428,13 +7692,6 @@
                 "inherits": "^2.0.1",
                 "minimalistic-assert": "^1.0.0"
             }
-        },
-        "node_modules/asn1.js/node_modules/bn.js": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/assert": {
             "version": "1.5.1",
@@ -7918,9 +8175,9 @@
             "license": "MIT"
         },
         "node_modules/bn.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-            "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+            "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
             "dev": true,
             "license": "MIT"
         },
@@ -8941,13 +9198,6 @@
                 "elliptic": "^6.5.3"
             }
         },
-        "node_modules/create-ecdh/node_modules/bn.js": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/create-hash": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -9416,13 +9666,6 @@
                 "randombytes": "^2.0.0"
             }
         },
-        "node_modules/diffie-hellman/node_modules/bn.js": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/doctrine": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -9666,13 +9909,6 @@
                 "minimalistic-crypto-utils": "^1.0.1"
             }
         },
-        "node_modules/elliptic/node_modules/bn.js": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -9711,14 +9947,14 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.18.4",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-            "integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+            "version": "5.20.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+            "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
-                "tapable": "^2.2.0"
+                "tapable": "^2.3.0"
             },
             "engines": {
                 "node": ">=10.13.0"
@@ -11457,6 +11693,23 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/glob-to-regex.js": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+            "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
         "node_modules/glob-to-regexp": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
@@ -11827,9 +12080,9 @@
             }
         },
         "node_modules/html-webpack-plugin": {
-            "version": "5.6.5",
-            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.5.tgz",
-            "integrity": "sha512-4xynFbKNNk+WlzXeQQ+6YYsH2g7mpfPszQZUi3ovKlj+pDmngQ7vRXjrrmGROabmKwyQkcgcX5hqfOwHbFmK5g==",
+            "version": "5.6.6",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz",
+            "integrity": "sha512-bLjW01UTrvoWTJQL5LsMRo1SypHW80FTm12OJRSnr3v6YHNhfe+1r0MYUZJMACxnCHURVnBWRwAsWs2yPU9Ezw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11906,6 +12159,16 @@
             "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/hyperdyperid": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+            "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            }
         },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
@@ -13118,19 +13381,6 @@
                 "semver": "bin/semver"
             }
         },
-        "node_modules/map-age-cleaner": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-            "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "p-defer": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -13191,23 +13441,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/mem": {
-            "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/mem/-/mem-8.1.1.tgz",
-            "integrity": "sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "map-age-cleaner": "^0.1.3",
-                "mimic-fn": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/mem?sponsor=1"
             }
         },
         "node_modules/memfs": {
@@ -13349,13 +13582,6 @@
                 "miller-rabin": "bin/miller-rabin"
             }
         },
-        "node_modules/miller-rabin/node_modules/bn.js": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -13390,16 +13616,6 @@
             },
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/mimic-fn": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-            "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/min-document": {
@@ -14201,16 +14417,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/p-defer": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-            "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -14926,13 +15132,6 @@
                 "safe-buffer": "^5.1.2"
             }
         },
-        "node_modules/public-encrypt/node_modules/bn.js": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/pump": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -15579,26 +15778,6 @@
                 "strip-ansi": "^6.0.1"
             }
         },
-        "node_modules/repeat-element": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
-            "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10"
-            }
-        },
         "node_modules/require-from-string": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -16082,13 +16261,13 @@
             "license": "MIT"
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+            "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "dependencies": {
-                "randombytes": "^2.1.0"
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/serve-static": {
@@ -16392,60 +16571,6 @@
                 "source-map": "^0.5.6",
                 "source-map-resolve": "^0.5.0",
                 "use": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/snapdragon-node": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/snapdragon-node/node_modules/define-property": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-            "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-descriptor": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/snapdragon-util": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "kind-of": "^3.2.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/snapdragon-util/node_modules/kind-of": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-buffer": "^1.1.5"
             },
             "engines": {
                 "node": ">=0.10.0"
@@ -17288,9 +17413,9 @@
             }
         },
         "node_modules/terser-webpack-plugin/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -17372,6 +17497,23 @@
             },
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/thingies": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+            "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "^2"
             }
         },
         "node_modules/through2": {
@@ -17613,6 +17755,23 @@
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/tree-dump": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+            "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -19107,9 +19266,9 @@
             "license": "MIT"
         },
         "node_modules/watchpack": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.0.tgz",
-            "integrity": "sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+            "integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19168,43 +19327,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/watchpack-chokidar2/node_modules/braces": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/braces/node_modules/extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "is-extendable": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/watchpack-chokidar2/node_modules/chokidar": {
             "version": "2.1.8",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -19227,37 +19349,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "^1.2.7"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/fill-range": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-            "integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/fill-range/node_modules/extend-shallow": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-            "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "is-extendable": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/watchpack-chokidar2/node_modules/fsevents": {
@@ -19315,45 +19406,6 @@
             "optional": true,
             "dependencies": {
                 "binary-extensions": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/is-number": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-            "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "kind-of": "^3.0.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/watchpack-chokidar2/node_modules/is-number/node_modules/kind-of": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-            "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "is-buffer": "^1.1.5"
             },
             "engines": {
                 "node": ">=0.10.0"
@@ -19445,21 +19497,6 @@
                 "safe-buffer": "~5.1.0"
             }
         },
-        "node_modules/watchpack-chokidar2/node_modules/to-regex-range": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-            "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -19468,9 +19505,9 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/webpack": {
-            "version": "5.104.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-            "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+            "version": "5.105.3",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.3.tgz",
+            "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19480,11 +19517,11 @@
                 "@webassemblyjs/ast": "^1.14.1",
                 "@webassemblyjs/wasm-edit": "^1.14.1",
                 "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.15.0",
+                "acorn": "^8.16.0",
                 "acorn-import-phases": "^1.0.3",
                 "browserslist": "^4.28.1",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.4",
+                "enhanced-resolve": "^5.19.0",
                 "es-module-lexer": "^2.0.0",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -19497,8 +19534,8 @@
                 "schema-utils": "^4.3.3",
                 "tapable": "^2.3.0",
                 "terser-webpack-plugin": "^5.3.16",
-                "watchpack": "^2.4.4",
-                "webpack-sources": "^3.3.3"
+                "watchpack": "^2.5.1",
+                "webpack-sources": "^3.3.4"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -19517,20 +19554,21 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-6.1.3.tgz",
-            "integrity": "sha512-A4ChP0Qj8oGociTs6UdlRUGANIGrCDL3y+pmQMc+dSsraXHCatFpmMey4mYELA+juqwUqwQsUgJJISXl1KWmiw==",
+            "version": "7.4.5",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+            "integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^3.4.12",
-                "mime-types": "^2.1.31",
+                "memfs": "^4.43.1",
+                "mime-types": "^3.0.1",
+                "on-finished": "^2.4.1",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
             },
             "engines": {
-                "node": ">= 14.15.0"
+                "node": ">= 18.12.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -19546,9 +19584,9 @@
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -19581,6 +19619,63 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/webpack-dev-middleware/node_modules/memfs": {
+            "version": "4.56.10",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.10.tgz",
+            "integrity": "sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@jsonjoy.com/fs-core": "4.56.10",
+                "@jsonjoy.com/fs-fsa": "4.56.10",
+                "@jsonjoy.com/fs-node": "4.56.10",
+                "@jsonjoy.com/fs-node-builtins": "4.56.10",
+                "@jsonjoy.com/fs-node-to-fsa": "4.56.10",
+                "@jsonjoy.com/fs-node-utils": "4.56.10",
+                "@jsonjoy.com/fs-print": "4.56.10",
+                "@jsonjoy.com/fs-snapshot": "4.56.10",
+                "@jsonjoy.com/json-pack": "^1.11.0",
+                "@jsonjoy.com/util": "^1.9.0",
+                "glob-to-regex.js": "^1.0.1",
+                "thingies": "^2.5.0",
+                "tree-dump": "^1.0.3",
+                "tslib": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/streamich"
+            },
+            "peerDependencies": {
+                "tslib": "2"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/webpack-dev-middleware/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
         },
         "node_modules/webpack-dev-middleware/node_modules/schema-utils": {
             "version": "4.3.3",
@@ -19615,9 +19710,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-            "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+            "integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -19632,9 +19727,9 @@
             "license": "MIT"
         },
         "node_modules/webpack/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -60,13 +60,13 @@
     "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@reduxjs/toolkit": "^2.8.2",
-        "@storybook/addon-actions": "^8.6.15",
-        "@storybook/addon-essentials": "^8.6.15",
-        "@storybook/addon-interactions": "^8.6.15",
-        "@storybook/addon-links": "^8.6.15",
-        "@storybook/builder-webpack5": "^8.6.15",
+        "@storybook/addon-actions": "^8.6.17",
+        "@storybook/addon-essentials": "^8.6.17",
+        "@storybook/addon-interactions": "^8.6.17",
+        "@storybook/addon-links": "^8.6.17",
+        "@storybook/builder-webpack5": "^8.6.17",
         "@storybook/manager-webpack5": "^6.5.16",
-        "@storybook/react": "^8.6.15",
+        "@storybook/react": "^8.6.17",
         "@storybook/testing-library": "0.2.2",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
@@ -103,6 +103,13 @@
         "vite-plugin-eslint": "^1.8.1",
         "vite-plugin-static-copy": "^2.2.0",
         "vite-plugin-svgr": "^4.3.0"
+    },
+    "overrides": {
+        "rollup": "^4.59.0",
+        "serialize-javascript": "^7.0.3",
+        "braces": ">=3.0.3",
+        "bn.js": "5.2.3",
+        "webpack-dev-middleware": ">=5.3.4"
     },
     "scripts": {
         "lint": "eslint \"src/**/*.{js,jsx}\" --quiet",


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

1. Storybook (e.g. Dependabot WebSocket hijacking – GHSA-mjf5-7g4m-gx5w)
Bumped all @storybook/* packages from ^8.6.15 to ^8.6.17 (patched version).
2. Rollup path traversal (GHSA-mw96-cpmx-2vgc)
Added override: "rollup": "^4.59.0" so Vite, tsup, and plugins use Rollup ≥ 4.59.0.
3. Other high-severity issues
serialize-javascript (RCE – GHSA-5c6j-r48x-rmvq): override "^7.0.3".
braces (resource consumption): override ">=3.0.3".
bn.js (infinite loop): override "5.2.3".
4. package.json changes
devDependencies: @storybook/addon-actions, addon-essentials, addon-interactions, addon-links, builder-webpack5, react set to ^8.6.17.
overrides:
rollup, serialize-javascript, braces, bn.js as above.
5. .gitignore
Added .npm-cache (used for installs when the global npm cache has permission issues).
6. Unpinned tag – JS-DevTools/npm-publish (Alert #8)
Vulnerability: uses: JS-DevTools/npm-publish@v4 — tag can change, supply chain risk.
Fix applied: Replaced with pinned commit:
uses: JS-DevTools/npm-publish@0fd2f4369c5d6bcfcde6091a7c527d810b9b5c3f
Will it fix it? Yes. CodeQL’s “unpinned tag” finding is resolved by using an immutable commit SHA.
7. Unpinned tag – softprops/action-gh-release (Alert #9)
Vulnerability: uses: softprops/action-gh-release@v1 — same supply chain concern.
Fix applied: Replaced with pinned commit:
uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
Will it fix it? Yes. Same as above; the workflow now uses a fixed commit.
---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [ ] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [ ] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue:
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
