### PR TITLE
Fix styles issues in federated apps

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,1 +1,1 @@
-<div id="overlay_container"></div>
+<div id="mlrun_overlay_container"></div>

--- a/src/lib/components/FormChipCell/HiddenChipsBlock/HiddenChipsBlock.jsx
+++ b/src/lib/components/FormChipCell/HiddenChipsBlock/HiddenChipsBlock.jsx
@@ -98,7 +98,7 @@ let HiddenChipsBlock = (
         })}
       </div>
     </div>,
-    document.getElementById('overlay_container')
+    document.getElementById('mlrun_overlay_container')
   )
 }
 

--- a/src/lib/components/Loader/LoaderForSuspenseFallback.jsx
+++ b/src/lib/components/Loader/LoaderForSuspenseFallback.jsx
@@ -23,7 +23,7 @@ import Loader from './Loader'
 
 const LoaderForSuspenseFallback = () => {
   useLayoutEffect(() => {
-    const overlayContainer = document.getElementById('overlay_container')
+    const overlayContainer = document.getElementById('mlrun_overlay_container')
     const savedVisibilityStyle = overlayContainer ? overlayContainer.style.visibility : 'visible'
 
     if (overlayContainer) overlayContainer.style.visibility = 'hidden'

--- a/src/lib/components/PopUpDialog/PopUpDialog.jsx
+++ b/src/lib/components/PopUpDialog/PopUpDialog.jsx
@@ -172,7 +172,7 @@ let PopUpDialog = (
             {children}
           </div>
         </div>,
-        document.getElementById('overlay_container')
+        document.getElementById('mlrun_overlay_container')
       )
     : null
 }

--- a/src/lib/components/Tip/Tip.jsx
+++ b/src/lib/components/Tip/Tip.jsx
@@ -114,7 +114,7 @@ const Tip = ({ className = '', text, withExclamationMark = false }) => {
             {text}
           </div>
         </CSSTransition>,
-        document.getElementById('overlay_container')
+        document.getElementById('mlrun_overlay_container')
       )}
     </div>
   )

--- a/src/lib/components/Tooltip/Tooltip.jsx
+++ b/src/lib/components/Tooltip/Tooltip.jsx
@@ -210,7 +210,7 @@ let Tooltip = ({
               {template}
             </div>
           </CSSTransition>,
-          document.getElementById('overlay_container')
+          document.getElementById('mlrun_overlay_container')
         )}
     </>
   )

--- a/src/lib/scss/common.scss
+++ b/src/lib/scss/common.scss
@@ -30,7 +30,7 @@
   isolation: isolate;
 }
 
-#overlay_container {
+#mlrun_overlay_container {
   position: fixed;
   bottom: 0;
   z-index: 2;


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://iguazio.atlassian.net/browse/IG4-1936
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
