### PR TITLE
[FEAT] Add overlay prop to Loader component for container-scoped loading state

### DIFF
--- a/src/lib/components/Loader/Loader.jsx
+++ b/src/lib/components/Loader/Loader.jsx
@@ -23,9 +23,10 @@ import PropTypes from 'prop-types'
 
 import './loader.scss'
 
-const Loader = ({ secondary = false, section = false, small = false }) => {
+const Loader = ({ overlay = false, secondary = false, section = false, small = false }) => {
   const wrapperClassNames = classnames(
     'loader-wrapper',
+    overlay && 'overlay-loader',
     section && 'section-loader',
     small && 'small-loader',
     secondary && 'secondary-loader'
@@ -56,6 +57,7 @@ const Loader = ({ secondary = false, section = false, small = false }) => {
 }
 
 Loader.propTypes = {
+  overlay: PropTypes.bool,
   secondary: PropTypes.bool,
   section: PropTypes.bool,
   small: PropTypes.bool

--- a/src/lib/components/Loader/loader.scss
+++ b/src/lib/components/Loader/loader.scss
@@ -10,6 +10,15 @@
   background-color: rgb(0 0 0 / 20%);
   inset: 0;
 
+  &.overlay-loader {
+    position: absolute;
+    z-index: 10;
+    background-color: transparent;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
   &.section-loader {
     position: relative;
     z-index: 10;


### PR DESCRIPTION
## 📝 Description
Previously, `<Loader />` used `position: fixed` and covered the entire viewport, blocking navigation, filters, and other UI controls during data fetching. This PR adds an `overlay` prop that scopes the loader to its nearest positioned parent container, allowing users to interact with the rest of the page while content is loading

---

## 🛠️ Changes Made
- Added `overlay` boolean prop to `Loader` component
- Added `.overlay-loader` CSS class (`position: absolute; inset: 0`) in `loader.scss`

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [x] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn't introduce new console warnings or lint / formatting errors
- [ ] I updated the relevant Jira ticket with the appropriate details and status

---

## 🚨 Potentially Breaking Changes
- [x] No

## 🔍 Additional Notes
- The parent container must have `position: relative` for `overlay` to work correctly