### PR TITLE
[FIX] EllipsisTooltip tooltip not showing on truncated text

### DIFF
--- a/src/lib/nextGenComponents/components/EllipsisTooltip/EllipsisTooltip.tsx
+++ b/src/lib/nextGenComponents/components/EllipsisTooltip/EllipsisTooltip.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef, useState } from 'react'
+import { ComponentPropsWithoutRef, ReactNode, useRef, useState } from 'react'
 
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
@@ -6,17 +6,16 @@ import { cn } from '@/lib/utils'
 type EllipsisTooltipProps = {
   children: ReactNode
   className?: string
-}
+} & Omit<ComponentPropsWithoutRef<typeof TooltipContent>, 'children'>
 
-const EllipsisTooltip = ({ children, className }: EllipsisTooltipProps) => {
+const EllipsisTooltip = ({ children, className, ...tooltipContentProps }: EllipsisTooltipProps) => {
   const ref = useRef<HTMLDivElement>(null)
   const [isOverflowed, setIsOverflowed] = useState(false)
 
-  useEffect(() => {
-    const text = ref.current
-    if (!text) return
-    setIsOverflowed(text.scrollWidth > text.clientWidth)
-  }, [children])
+  const handleOpenChange = (open: boolean) => {
+    if (!open) { setIsOverflowed(false); return }
+    if (ref.current) setIsOverflowed(ref.current.scrollWidth > ref.current.clientWidth)
+  }
 
   const content = (
     <div ref={ref} className={cn('truncate overflow-hidden text-ellipsis w-full', className)}>
@@ -24,12 +23,10 @@ const EllipsisTooltip = ({ children, className }: EllipsisTooltipProps) => {
     </div>
   )
 
-  if (!isOverflowed) return content
-
   return (
-    <Tooltip>
+    <Tooltip open={isOverflowed} onOpenChange={handleOpenChange}>
       <TooltipTrigger asChild>{content}</TooltipTrigger>
-      <TooltipContent className="break-words *:text-white [&_*]:text-white">
+      <TooltipContent className="break-words *:text-white [&_*]:text-white" {...tooltipContentProps}>
         <div className="select-text">{children}</div>
       </TooltipContent>
     </Tooltip>

--- a/src/lib/nextGenComponents/components/EllipsisTooltip/EllipsisTooltip.tsx
+++ b/src/lib/nextGenComponents/components/EllipsisTooltip/EllipsisTooltip.tsx
@@ -13,7 +13,10 @@ const EllipsisTooltip = ({ children, className, ...tooltipContentProps }: Ellips
   const [isOverflowed, setIsOverflowed] = useState(false)
 
   const handleOpenChange = (open: boolean) => {
-    if (!open) { setIsOverflowed(false); return }
+    if (!open) {
+      setIsOverflowed(false)
+      return
+    }
     if (ref.current) setIsOverflowed(ref.current.scrollWidth > ref.current.clientWidth)
   }
 
@@ -26,7 +29,10 @@ const EllipsisTooltip = ({ children, className, ...tooltipContentProps }: Ellips
   return (
     <Tooltip open={isOverflowed} onOpenChange={handleOpenChange}>
       <TooltipTrigger asChild>{content}</TooltipTrigger>
-      <TooltipContent className="break-words *:text-white [&_*]:text-white" {...tooltipContentProps}>
+      <TooltipContent
+        className="break-words *:text-white [&_*]:text-white"
+        {...tooltipContentProps}
+      >
         <div className="select-text">{children}</div>
       </TooltipContent>
     </Tooltip>


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
[FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
[STYLE] Reformat components for linting compliance
[CI] Run tests on push for all branches
[FEAT] Add dark mode toggle in header
-->

## 📝 Description
<!-- A clear, concise summary of what this PR does. -->
<!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

`EllipsisTooltip` used a `useEffect` to measure overflow after mount, but Radix applies the `--radix-popper-anchor-width` CSS variable asynchronously via its own layout effect. By the time the effect ran, the element had no width constraint, so `scrollWidth === clientWidth` and `isOverflowed` stayed `false` — the tooltip never appeared.
The fix replaces the effect with a controlled `Tooltip` whose `onOpenChange` checks overflow at the moment the user hovers, guaranteeing the measurement happens after the element is fully laid out. 

Additionally, `EllipsisTooltipProps` now extends all `TooltipContent` props so callers can control positioning (`side`, `align`, `sideOffset`,`alignOffset`, etc.) without extra wrappers.

---

## 🛠️ Changes Made
<!-- List the main updates in this PR. -->
<!-- Example:
- Replaced Sass styles with CSS Modules
- Updated Button component props for accessibility
- Adjusted CI workflow to run on push for all branches
-->

- Replaced `useEffect` overflow detection with `onOpenChange`- based check at hover time
- Tooltip render tree is now always consistent (no conditional structural change)
- Extended `EllipsisTooltipProps` with `Omit<ComponentPropsWithoutRef<typeof TooltipContent>, 'children'>`

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/ML-12803
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
- TODO: Migrate remaining components away from Sass
- Known issue: minor layout flicker on mobile
-->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

<img width="339" height="340" alt="Screenshot 2026-07-08 at 15 24 32" src="https://github.com/user-attachments/assets/7621e103-da0f-4999-ac02-c9d85dd558ac" />

---
