### PR TITLE
[FIX] [Navbar] ‘Pin sidebar’ button disappears when search dropdown is opened

### DIFF
--- a/src/lib/nextGenComponents/components/ui/sidebar.tsx
+++ b/src/lib/nextGenComponents/components/ui/sidebar.tsx
@@ -265,29 +265,27 @@ const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(
             className="flex size-full flex-col bg-sidebar shadow-[1px_4px_16px_rgba(0,0,0,0.04)] group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
           >
             {children}
-            <Button
-              variant="outline"
-              tooltip={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
-              data-testid="pin-sidebar-button"
-              data-sidebar="pin"
-              aria-hidden={!open}
-              tabIndex={open ? 0 : -1}
-              side="right"
-              className={cn(
-                'absolute top-2 left-full border bg-[#FAFAFA] border-gray-200 border-solid',
-                'w-fit h-fit rounded-l-none border-l-0 py-2 pr-[3px] pl-[1px]',
-                'transition-visibility hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-
-                !open && 'hidden'
-              )}
-              onClick={togglePin}
-            >
-              {pinned ? (
-                <SidebarClose data-testid="closeed-pin" />
-              ) : (
-                <SidebarOpen data-testid="opened-pin" />
-              )}
-            </Button>
+            {open && (
+              <Button
+                variant="outline"
+                tooltip={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+                data-testid="pin-sidebar-button"
+                data-sidebar="pin"
+                side="right"
+                className={cn(
+                  'absolute top-2 left-full border bg-[#FAFAFA] border-gray-200 border-solid',
+                  'w-fit h-fit rounded-l-none border-l-0 py-2 pr-[3px] pl-[1px]',
+                  'transition-visibility hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'
+                )}
+                onClick={togglePin}
+              >
+                {pinned ? (
+                  <SidebarClose data-testid="closeed-pin" />
+                ) : (
+                  <SidebarOpen data-testid="opened-pin" />
+                )}
+              </Button>
+            )}
           </div>
         </div>
       </nav>

--- a/src/lib/nextGenComponents/components/ui/sidebar.tsx
+++ b/src/lib/nextGenComponents/components/ui/sidebar.tsx
@@ -265,27 +265,29 @@ const Sidebar = React.forwardRef<HTMLElement, SidebarProps>(
             className="flex size-full flex-col bg-sidebar shadow-[1px_4px_16px_rgba(0,0,0,0.04)] group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
           >
             {children}
-            {open && (
-              <Button
-                variant="outline"
-                tooltip={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
-                data-testid="pin-sidebar-button"
-                side="right"
-                className={cn(
-                  'absolute top-2 left-full border bg-[#FAFAFA] border-gray-200 border-solid',
-                  'w-fit h-fit rounded-l-none border-l-0 py-2 pr-[3px] pl-[1px]',
-                  'transition-opacity hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
-                  pinned ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
-                )}
-                onClick={togglePin}
-              >
-                {pinned ? (
-                  <SidebarClose data-testid="closeed-pin" />
-                ) : (
-                  <SidebarOpen data-testid="opened-pin" />
-                )}
-              </Button>
-            )}
+            <Button
+              variant="outline"
+              tooltip={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+              data-testid="pin-sidebar-button"
+              data-sidebar="pin"
+              aria-hidden={!open}
+              tabIndex={open ? 0 : -1}
+              side="right"
+              className={cn(
+                'absolute top-2 left-full border bg-[#FAFAFA] border-gray-200 border-solid',
+                'w-fit h-fit rounded-l-none border-l-0 py-2 pr-[3px] pl-[1px]',
+                'transition-visibility hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+
+                !open && 'hidden'
+              )}
+              onClick={togglePin}
+            >
+              {pinned ? (
+                <SidebarClose data-testid="closeed-pin" />
+              ) : (
+                <SidebarOpen data-testid="opened-pin" />
+              )}
+            </Button>
           </div>
         </div>
       </nav>


### PR DESCRIPTION
<!-- Title structure should start with a flag - either of these:
  [FEAT] [FIX] [CHORE] [CI] [DOCS] [STYLE] [REFACTOR] [TEST] [BUILD] [PERF]
Followed by a clear representation - e.g:
  [STYLE] Reformat components for linting compliance
  [CI] Run tests on push for all branches
  [FEAT] Add dark mode toggle in header
  -->
  
  ## 📝 Description
  <!-- A clear, concise summary of what this PR does. -->
  <!-- Include context, motivation, or related issues (e.g., "Replaces Sass with CSS Modules"). -->

---

## 🛠️ Changes Made
  <!-- List the main updates in this PR. -->
<!-- Example:
  - Replaced Sass styles with CSS Modules
  - Updated Button component props for accessibility
  - Adjusted CI workflow to run on push for all branches
  -->

---

## ✅ Checklist

- [x] I have given the PR a well-structured title describing the domain and the specific change that was made
- [x] I tested the changes in the browser (locally or via preview build)
- [ ] I confirmed that existing tests pass
- [ ] I added or updated unit / integration tests (if needed)
- [x] I checked that this change doesn’t introduce new console warnings or lint / formatting errors
- [x] I updated the relevant Jira ticket with the appropriate details and status


---

## 🔗 References
- Related ticket / issue: https://ecliptos.atlassian.net/browse/ML-12815
- Figma / design spec:
- Documentation:

---

## 🚨 Potentially Breaking Changes
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->
<!-- Example: Renamed prop `variant` → `type` in Button component -->

## 🔍 Additional Notes
<!-- Optional: other context, performance considerations, or follow-up work -->
<!-- Example:
  - TODO: Migrate remaining components away from Sass
  - Known issue: minor layout flicker on mobile
  -->

---

## 📸 Screenshots / Demos
<!-- Include before/after screenshots, GIFs, or video demos if the change affects UI. -->
<!-- You can drag and drop images here directly in the PR. -->

---
